### PR TITLE
Add sad paths for non existing merchant and item ids

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,15 +2,30 @@ class ItemsController<ApplicationController
 
   def index
     if params[:merchant_id]
-      @merchant = Merchant.find(params[:merchant_id])
-      @items = @merchant.items
+      if Merchant.exists?(id: params[:merchant_id])
+        @merchant = Merchant.find(params[:merchant_id])
+        @items = @merchant.items
+      else
+        flash.notice = 'This merchant does not exist. Please select an existing merchant.'
+        redirect_to '/merchants'
+      end
     else
       @items = Item.all
     end
   end
 
   def show
-    @item = Item.find(params[:id])
+    if Item.exists?(id: params[:id])
+      @item = Item.find(params[:id])
+    else
+      if params[:merchant_id]
+        flash.notice = 'This item does not exist. Please select an existing item.'
+        redirect_to "/merchants/#{params[:merchant_id]}/items"
+      else
+        flash.notice = 'This item does not exist. Please select an existing item.'
+        redirect_to "/items"
+      end
+    end
   end
 
   def new

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -5,7 +5,12 @@ class MerchantsController <ApplicationController
   end
 
   def show
-    @merchant = Merchant.find(params[:id])
+    if Merchant.exists?(id: params[:id])
+      @merchant = Merchant.find(params[:id])
+    else
+      flash.notice = 'This merchant does not exist. Please select an existing merchant.'
+      redirect_to '/merchants'
+    end
   end
 
   def new

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   get "/merchants/:merchant_id/items/new", to: "items#new"
   post "/merchants/:merchant_id/items", to: "items#create"
   delete "/items/:id", to: "items#destroy"
+  get '/merchants/:merchant_id/items/:item_id', to: 'items#show'
 
   get "/items/:item_id/reviews/new", to: "reviews#new"
   post "/items/:item_id", to: "reviews#create"
@@ -36,4 +37,5 @@ Rails.application.routes.draw do
   get '/orders/new', to: 'orders#new'
   post '/orders', to: 'orders#create'
   get '/orders/:order_id', to: 'orders#show'
+
 end

--- a/spec/features/items/merchant_items_index_spec.rb
+++ b/spec/features/items/merchant_items_index_spec.rb
@@ -39,5 +39,20 @@ RSpec.describe "Merchant Items Index Page" do
         expect(page).to have_content("Inventory: #{@shifter.inventory}")
       end
     end
+
+    it 'shows a flash message that the merchant does not exist if I type an unknown id in the url' do
+      visit '/merchants/35466/items'
+
+      expect(current_path).to eq('/merchants')
+      expect(page).to have_content('This merchant does not exist. Please select an existing merchant.')
+    end
+
+    it 'shows a flash message that the item for this merchant does not exist if I type an unknown id in the url' do
+      visit "/merchants/#{@meg.id}/items/2458295"
+
+      expect(current_path).to eq("/merchants/#{@meg.id}/items")
+      expect(page).to have_content('This item does not exist. Please select an existing item.')
+    end
   end
+
 end

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe 'item show page', type: :feature do
     expect(page).to have_content('Reviews')
   end
 
+  it 'shows a flash message that the item does not exist if I type an unknown id in the url' do
+    visit '/items/35466'
+
+    expect(current_path).to eq('/items')
+    expect(page).to have_content('This item does not exist. Please select an existing item.')
+  end
+
   it 'shows list of review for that item' do
     within "#review-#{@review_2.id}" do
       expect(page).to have_content("Awesome chain!")
@@ -89,7 +96,7 @@ RSpec.describe 'item show page', type: :feature do
       expect(page).to have_content('Rating: 2')
       expect(page).to have_content('Rating: 3')
     end
-    
+
     expect(page).to have_content('Average Rating: 3.33')
   end
 end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe 'merchant show page', type: :feature do
       expect(current_path).to eq("/merchants/#{@bike_shop.id}/items")
     end
 
+    it 'shows a flash message that the merchant does not exist if I type an unknown id in the url' do
+      visit '/merchants/506'
+
+      expect(current_path).to eq('/merchants')
+      expect(page).to have_content('This merchant does not exist. Please select an existing merchant.')
+    end
+
     it 'I see merchant statistics ' do
       @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 50.00, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
       @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 25.05, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)


### PR DESCRIPTION
*Add sad path for no existing merchant id redirect to merchants
*Add sad path no item id to items
*Add sad path no items for a non-existing merchant redirect to merchant index
*Add sad path no item for an existing merchant return to merchant items index
*All tests passing

Co-authored-by: Laura Schulz <30582885+lrs8810@users.noreply.github.com>